### PR TITLE
translate complex words

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,24 @@
 
 Utility to help convert grammars written for [tree-sitter](https://tree-sitter.github.io/) to Lezer's grammar notation.
 
+## Status
+
 This isn't a polished easy-to-use tool, but might help save time when porting a grammar.
 
+## Usage
+
+### CLI
+
+```sh
+npm install -g https://github.com/lezer-parser/import-tree-sitter
+lezer-import-tree-sitter src/grammar.json >some_language.grammar
+```
+
+### API
+
 If you pass the tree-sitter grammar JSON representation (usually in `src/grammar.json`), as a string, to the `buildGrammar` function defined in `src/import.ts`, it'll spit out an equivalent Lezer grammar file.
+
+## Limitations
 
 Because tree-sitter's concepts don't all map to Lezer concepts, you'll only get a working, finished grammar for very trivial grammars. Specifically:
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "prepare": "tsc",
+    "watch": "tsc --watch",
     "build": "tsc"
   },
   "dependencies": {

--- a/src/import.ts
+++ b/src/import.ts
@@ -252,7 +252,7 @@ class Context {
         else throw new RangeError("Word token too complex")
       }
       this.wordRuleName = this.def.rules["_kw"] ? this.generateName("kw") : "kw"
-      this.wordRule = `${this.wordRuleName}<term> { @specialize[name={term}]<${this.translateName(this.def.word)}, term> }\n\n`
+      this.wordRule = `${this.wordRuleName}<term> { @specialize[@name={term}]<${this.translateName(this.def.word)}, term> }\n\n`
       this.wordRE = new RegExp("^(" + pattern + ")$")
     }
 

--- a/src/import.ts
+++ b/src/import.ts
@@ -229,6 +229,7 @@ class Context {
       for (let part of expr.type == "SEQ" ? expr.members : [expr]) {
         if (part.type == "STRING") pattern += part.value.replace(/[^\w\s]/g, "\\$&")
         else if (part.type == "PATTERN") pattern += part.value
+        else if (part.type == "TOKEN") pattern += this.translateExpr(part.content, true)
         else throw new RangeError("Word token too complex")
       }
       this.wordRuleName = this.def.rules["_kw"] ? this.generateName("kw") : "kw"


### PR DESCRIPTION
make it work with [tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash/blob/master/grammar.js)

```js
    word: $ => token(seq(
      choice(
        noneOf('#', ...SPECIAL_CHARACTERS),
        seq('\\', noneOf('\\s'))
      ),
      repeat(choice(
        noneOf(...SPECIAL_CHARACTERS),
        seq('\\', noneOf('\\s'))
      ))
    )),
```

error was

> RangeError: Word token too complex

now word is translated to

```lezer
@tokens {
  Word {
    (![#'"<>{}\[\]()`$|&;\\ \t\n\r] | "\\" ![ \t\n\r]) (!['"<>{}\[\]()`$|&;\\ \t\n\r] | "\\" ![ \t\n\r])*
  }
}
```

